### PR TITLE
Upgrade to ghc-lib-8.8.0.20190723

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -6,4 +6,4 @@ packages:
 extra-deps:
   - haskell-src-exts-1.21.0
   - haskell-src-exts-util-0.2.5
-  - archive: https://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-parser-8.8.0.20190704.tar.gz
+  - archive: https://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-parser-8.8.0.20190723.tar.gz


### PR DESCRIPTION
Upgrade to the ghc-8.8.1-rc1 based `ghc-lib` version.