### PR TITLE
Expose read files config

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,7 @@
 Changelog for HLint (* = breaking change)
 
+2.2.2, released 2019-07-23
+    #716, upgrade to ghc-lib-parser 8.8.0.20190723
 2.2.1, released 2019-07-22
     #713, make sure -XNoPatternSynonyms works (fix regression)
     #700, add some Monoid and Alternative hints

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ HLint can generate a lot of information, making it difficult to search for parti
 
 ### Language Extensions
 
-HLint enables most Haskell extensions, disabling only those which steal too much syntax (currently Arrows, TransformListComp, XmlSyntax and RegularPatterns). Individual extensions can be enabled or disabled with, for instance, `-XArrows`, or `-XNoMagicHash`. The flag `-XHaskell2010` selects Haskell 2010 compatibility. You can also pass them via `.hlint.yaml` file. For example: `- arguments: [-XQuasiQuotes]`.
+HLint enables most Haskell extensions, disabling only those which steal too much syntax (e.g. Arrows, TransformListComp and TypeApplications). Individual extensions can be enabled or disabled with, for instance, `-XArrows`, or `-XNoMagicHash`. The flag `-XHaskell2010` selects Haskell 2010 compatibility. You can also pass them via `.hlint.yaml` file. For example: `- arguments: [-XArrows]`.
 
 ### Emacs Integration
 

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -515,7 +515,7 @@
     - warn: {lhs: maybe x f (fmap g y), rhs: maybe x (f . g) y, name: Redundant fmap}
     - warn: {lhs: isJust (fmap f x), rhs: isJust x}
     - warn: {lhs: isNothing (fmap f x), rhs: isNothing x}
-    - warn: {lhs: fromJust (fmap f x), rhs: f (fromJust x)}
+    - warn: {lhs: fromJust (fmap f x), rhs: f (fromJust x), note: IncreasesLaziness}
     - warn: {lhs: mapMaybe f (fmap g x), rhs: mapMaybe (f . g) x, name: Redundant fmap}
 
     # EITHER

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -1,7 +1,7 @@
 cabal-version:      >= 1.18
 build-type:         Simple
 name:               hlint
-version:            2.2.1
+version:            2.2.2
 license:            BSD3
 license-file:       LICENSE
 category:           Development

--- a/src/Language/Haskell/HLint4.hs
+++ b/src/Language/Haskell/HLint4.hs
@@ -19,7 +19,7 @@ module Language.Haskell.HLint4(
     -- * Settings
     Classify(..),
     getHLintDataDir, autoSettings, argsSettings,
-    findSettings, readSettingsFile,
+    findSettings, readSettingsFile, readFilesConfig,
     -- * Hints
     Hint, resolveHints,
     -- * Parse files

--- a/src/Language/Haskell/HLint4.hs
+++ b/src/Language/Haskell/HLint4.hs
@@ -19,7 +19,7 @@ module Language.Haskell.HLint4(
     -- * Settings
     Classify(..),
     getHLintDataDir, autoSettings, argsSettings,
-    findSettings, readSettingsFile, readFilesConfig,
+    findSettings, readSettingsFile, readFilesConfig, splitSettings,
     -- * Hints
     Hint, resolveHints,
     -- * Parse files


### PR DESCRIPTION
This PR exports a couple of routines from `HLint4.hs` we need to implement our own ".hlint.yaml" settings logic.