### PR TITLE
Ignore "use newtype instead of data" at source

### DIFF
--- a/src/Hint/NewType.hs
+++ b/src/Hint/NewType.hs
@@ -31,7 +31,7 @@ newtype Foo = Foo Int deriving stock Show
 -}
 module Hint.NewType (newtypeHint) where
 
-import Hint.Type (Idea, DeclHint', Note(DecreasesLaziness), ideaNote, ignoreNoSuggestion', suggestN')
+import Hint.Type (Idea, DeclHint', Note(DecreasesLaziness), ideaNote, ignoreNoSuggestion', ignoreN')
 
 import Data.List (isSuffixOf)
 import "ghc-lib-parser" HsDecls
@@ -45,7 +45,7 @@ newtypeHint _ _ x = newtypeHintDecl x ++ newTypeDerivingStrategiesHintDecl x
 newtypeHintDecl :: LHsDecl GhcPs -> [Idea]
 newtypeHintDecl old
     | Just WarnNewtype{newDecl, insideType} <- singleSimpleField old
-    = [(suggestN' "Use newtype instead of data" old newDecl)
+    = [(ignoreN' "Use newtype instead of data" old newDecl)
             {ideaNote = [DecreasesLaziness | warnBang insideType]}]
 newtypeHintDecl _ = []
 

--- a/src/Idea.hs
+++ b/src/Idea.hs
@@ -4,7 +4,7 @@
 module Idea(
     Idea(..),
     rawIdea, idea, idea', suggest, suggest', warn, warn',ignore, ignore',
-    rawIdeaN, suggestN, suggestN', ignoreN, ignoreNoSuggestion',
+    rawIdeaN, suggestN, suggestN', ignoreN, ignoreN', ignoreNoSuggestion',
     showIdeasJson, showANSI,
     Note(..), showNotes,
     Severity(..),
@@ -144,3 +144,7 @@ suggestN' = ideaN' Suggestion
 ignoreN :: (Annotated ast, Pretty a, Pretty (ast SrcSpanInfo)) =>
            String -> ast SrcSpanInfo -> a -> Idea
 ignoreN = ideaN Ignore
+
+ignoreN' :: (GHC.HasSrcSpan a, Outputable.Outputable a) =>
+           String -> a -> a -> Idea
+ignoreN' = ideaN' Ignore


### PR DESCRIPTION
Only the change to `NewType.hs` will persist - the change to `Idea.hs` I'll upstream.