### PR TITLE
Upgrade ghc-lib (v8.8.1.20190830) and expand CI coverage

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -15,10 +15,8 @@ import System.Time.Extra
 main :: IO ()
 main = do
   -- Linux only for now.
-  let extra_lib_dirs="`stack path --compiler-bin`/../lib/ghc-8.6.5/rts"
-      set_path = "LD_LIBRARY_PATH=" ++ extra_lib_dirs ++ " "
-  cmd $ set_path ++ "stack build --no-terminal --interleaved-output --extra-lib-dirs " ++ extra_lib_dirs
-  cmd $ set_path ++ "stack exec -- hlint test"
+  cmd "stack build --no-terminal --interleaved-output"
+  cmd "stack run -- test"
   where
     cmd :: String -> IO ()
     cmd x = do

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,8 @@ pr:
 strategy:
   matrix:
     linux:   {image: "Ubuntu 16.04"}
-    #windows: {image: "vs2017-win2016"}
-    #mac:      {image: "macOS-10.13"}
+    windows: {image: "vs2017-win2016"}
+    mac:     {image: "macOS-10.13"}
 
 pool: {vmImage: '$(image)'}
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,6 @@ packages: [.]
 extra-deps:
   - haskell-src-exts-1.21.0
   - haskell-src-exts-util-0.2.5
-  - archive: https://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-parser-8.8.1.20190828.1.tar.gz
+  - archive: https://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-parser-8.8.1.20190830.tar.gz
 ghc-options:
     "$locals": -Wunused-imports -Worphans -Wunused-top-binds


### PR DESCRIPTION
Upgrades ghc-lib, removes Ffi hacking and enables mac and Windows testing.