### PR TITLE
Extend CI coverage to include ghc-8.4.4

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -1,9 +1,11 @@
+#!/usr/bin/env stack runhaskell --package extra --package optparse-applicative --
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its
 -- affiliates. All rights reserved.  SPDX-License-Identifier:
 -- (Apache-2.0 OR BSD-3-Clause)
 
 -- CI script, compatible with all of Travis, Appveyor and Azure.
-
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 import Control.Monad
 import System.Directory
 import System.FilePath
@@ -11,17 +13,52 @@ import System.IO.Extra
 import System.Info.Extra
 import System.Process.Extra
 import System.Time.Extra
+import Data.Semigroup ((<>))
+import qualified Options.Applicative as Opts
 
 main :: IO ()
 main = do
-  -- Linux only for now.
-  cmd "stack build --no-terminal --interleaved-output"
-  cmd "stack run -- test"
+   let opts =
+         Opts.info (parseOptions Opts.<**> Opts.helper)
+         ( Opts.fullDesc
+           <> Opts.progDesc "Build and test hlint."
+           <> Opts.header "CI - CI script for hlint"
+         )
+   Options {stackYaml} <- Opts.execParser opts
+   process stackYaml
+
+stackYamlOpt :: Maybe String -> String
+stackYamlOpt = \case
+  Just file -> "--stack-yaml " ++ file
+  Nothing -> ""
+
+data Options = Options
+    { stackYaml :: Maybe String } deriving (Show)
+
+parseOptions :: Opts.Parser Options
+parseOptions = Options
+    <$> Opts.optional ( Opts.strOption
+        ( Opts.long "stack-yaml"
+          <> Opts.help "If specified, the stack-yaml file to use"
+        ))
+
+process :: Maybe String -> IO ()
+process config = do
+  -- Feedback on the compiler used for building hlint.
+  stack "exec -- ghc --version"
+  stack "--no-terminal --interleaved-output build"
+  stack "run -- test"
   where
-    cmd :: String -> IO ()
-    cmd x = do
-      putStrLn $ "\n\n# Running: " ++ x
-      hFlush stdout
-      (t, _) <- duration $ system_ x
-      putStrLn $ "# Completed in " ++ showDuration t ++ ": " ++ x ++ "\n"
-      hFlush stdout
+      stackYamlFlag :: String -- One of "" or, --stack-yaml=file.
+      stackYamlFlag = stackYamlOpt config
+
+      stack :: String -> IO ()
+      stack action = cmd $ "stack " ++ stackYamlFlag ++ " " ++ action
+
+      cmd :: String -> IO ()
+      cmd x = do
+        putStrLn $ "\n\n# Running: " ++ x
+        hFlush stdout
+        (t, _) <- duration $ system_ x
+        putStrLn $ "# Completed in " ++ showDuration t ++ ": " ++ x ++ "\n"
+        hFlush stdout

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,14 +13,32 @@ pr:
 
 strategy:
   matrix:
-    linux:   {image: "Ubuntu 16.04"}
-    windows: {image: "vs2017-win2016"}
-    mac:     {image: "macOS-10.13"}
+    # All configs use
+    # DA ghc-lib https://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-parser-8.8.1.20190830.tar.gz
+    linux-ghc-lib-881-844:
+      image: "Ubuntu 16.04"
+      stack-yaml: "stack-ghc-844.yaml"
+    windows-ghc-lib-881-844:
+      image: "vs2017-win2016"
+      stack-yaml: "stack-ghc-844.yaml"
+    mac-ghc-lib-881-844:
+      image: "macOS-10.13"
+      stack-yaml: "stack-ghc-844.yaml"
+
+    linux-ghc-lib-881-865:
+      image: "Ubuntu 16.04"
+      stack-yaml: "stack.yaml"
+    windows-ghc-lib-881-865:
+      image: "vs2017-win2016"
+      stack-yaml: "stack.yaml"
+    mac-ghc-lib-881-865:
+      image: "macOS-10.13"
+      stack-yaml: "stack.yaml"
 
 pool: {vmImage: '$(image)'}
 
 steps:
   - script: |
       curl -sSL https://get.haskellstack.org/ | sh
-      stack setup
-      stack runhaskell --package extra CI.hs
+      stack --stack-yaml $(stack-yaml) setup
+      stack runhaskell --stack-yaml $(stack-yaml) --package extra --package optparse-applicative CI.hs -- --stack-yaml $(stack-yaml)

--- a/stack-ghc-844.yaml
+++ b/stack-ghc-844.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.21 # ghc-8.6.5
+resolver: lts-12.26 # ghc-8.4.4
 packages: [.]
 extra-deps:
   - haskell-src-exts-1.21.0


### PR DESCRIPTION
Give `CI.hs` a stack-yaml option, provide a ghc-8.4.4 stack.yaml and extend the azure strategy matrix.